### PR TITLE
Add start/stop/ready/logs to Makefile, update README, and upgrade workflow actions

### DIFF
--- a/.github/workflows/cloudpod_release.yml
+++ b/.github/workflows/cloudpod_release.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.11
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
 
@@ -49,13 +49,13 @@ jobs:
 
 
       - name: Start LocalStackV2
-        uses: LocalStack/setup-localstack@v0.2.2
+        uses: LocalStack/setup-localstack@main
         with:
           image-tag: ${{ inputs.release-tag || 'latest'}}
           use-pro: "true"
           install-awslocal: "true"
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Deploy infrastructure
         working-directory: deployments/cdk
@@ -70,7 +70,7 @@ jobs:
       # Not using action as state is not stored as an artifact
       - name: Save the Cloud Pod
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           localstack state export release-pod.zip
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ${{ inputs.runner-os || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.11
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11
 
@@ -50,14 +50,14 @@ jobs:
           pip install -e ".[deploy,test]"
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
+        uses: LocalStack/setup-localstack@main
         with:
           image-tag: 'latest'
           use-pro: 'true'
           configuration: LS_LOG=trace
           install-awslocal: 'true'
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Set up NodeJS 22
         id: setup-nodejs

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -99,3 +99,10 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
+      - name: Prevent Workflows from getting Stale
+        if: always()
+        uses: gautamkrishnar/keepalive-workflow@v1
+        with:
+          # this message should prevent automatic triggering of workflows
+          # see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
+          commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"

--- a/.github/workflows/test_cloudpods.yml
+++ b/.github/workflows/test_cloudpods.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # checkout to run the tests later on
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Loading it manually as we're storing the state as a release and not an artifact
       - name: Retrieve Pod
@@ -55,7 +55,7 @@ jobs:
           python-version: '3.11'
 
       - name: Start LocalStack
-        uses: LocalStack/setup-localstack@v0.2.2
+        uses: LocalStack/setup-localstack@main
         with:
           image-tag: ${{ matrix.tag }}
           use-pro: 'true'
@@ -63,11 +63,11 @@ jobs:
         env:
           DEBUG: 1
           POD_LOAD_CLI_TIMEOUT: 300
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 
       - name: Inject Pod
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           localstack state import release-pod.zip
 
@@ -99,10 +99,3 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
-      - name: Prevent Workflows from getting Stale
-        if: always()
-        uses: gautamkrishnar/keepalive-workflow@v1
-        with:
-          # this message should prevent automatic triggering of workflows
-          # see https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs
-          commit_message: "[skip ci] Automated commit by Keepalive Workflow to keep the repository active"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,25 @@
+export AWS_ACCESS_KEY_ID ?= test
+export AWS_SECRET_ACCESS_KEY ?= test
+export AWS_DEFAULT_REGION=us-east-1
+SHELL := /bin/bash
+
+usage:		## Show this help
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
+
+start:		## Start LocalStack
+	@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+	@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) localstack start -d
+
+stop:		## Stop LocalStack
+	@localstack stop
+
+ready:		## Wait until LocalStack is ready
+	@echo Waiting on the LocalStack container...
+	@localstack wait -t 30 && echo LocalStack is ready to use! || (echo Gave up waiting on LocalStack, exiting. && exit 1)
+
+logs:		## Save the logs in a separate file
+	@localstack logs > logs.txt
+
 VENV_BIN = python3 -m venv
 VENV_DIR ?= .venv
 VENV_ACTIVATE = $(VENV_DIR)/bin/activate

--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ Wordpress deployed using ECS and RDS
 
 ## Quickstart
 
-to install python requirements and developer tools (ckdlocal, awslocal) into a venv run:
+To install python requirements and developer tools (cdklocal, awslocal) into a venv run:
 
     make install
 
-then, to deploy the cdk app, first start localstack and run
+Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+
+```bash
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
+make start
+make ready
+```
+
+Then, to deploy the CDK app:
 
     make deploy-local
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To install python requirements and developer tools (cdklocal, awslocal) into a v
 
     make install
 
-Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
+Start LocalStack for AWS with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```bash
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Wordpress deployed using ECS and RDS
 
 ## Quickstart
 
+This sample requires a valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
+
 To install python requirements and developer tools (cdklocal, awslocal) into a venv run:
 
     make install


### PR DESCRIPTION
## Summary
- Add `start`, `stop`, `ready`, `logs` targets to Makefile with `LOCALSTACK_AUTH_TOKEN` guard
- Update README to include `LOCALSTACK_AUTH_TOKEN` setup instructions
- Upgrade `actions/checkout@v2/v3` to `v4`, `actions/setup-python@v2` to `v4`
- Replace deprecated `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` in all workflows
- Upgrade `setup-localstack@v0.2.2` to `@main`
- Remove `keepalive-workflow` action from test_cloudpods workflow